### PR TITLE
fix: resolve Deno type-checking errors

### DIFF
--- a/src/lib/external-mcps/mcp_config.ts
+++ b/src/lib/external-mcps/mcp_config.ts
@@ -7,7 +7,7 @@ interface McpServerConfigBase {
   transport?: "stdio" | "streamable_http" | "sse";
 }
 
-interface McpServerConfigStdio extends BaseConfig {
+interface McpServerConfigStdio extends McpServerConfigBase {
   command: string;
   args: string[];
   env?: Record<string, string>;
@@ -16,7 +16,7 @@ interface McpServerConfigStdio extends BaseConfig {
   headers?: never;
 }
 
-interface McpServerConfigHttp extends BaseConfig {
+interface McpServerConfigHttp extends McpServerConfigBase {
   url: string;
   transport: "streamable_http" | "sse";
   headers?: Record<string, string>[];

--- a/src/lib/external-mcps/mcp_schema_fetcher.ts
+++ b/src/lib/external-mcps/mcp_schema_fetcher.ts
@@ -107,7 +107,7 @@ export class McpSchemaFetcher {
         return [];
       }
 
-      return response.resources.map((resource) => ({
+      return response.resources.map((resource: any) => ({
         name: this.sanitizeIdentifier(resource.name),
         originalName: resource.name,
         description: resource.description,


### PR DESCRIPTION
This PR fixes several Deno type-checking errors that were preventing the installation script from completing successfully.

Changes:
- **mcp_config.ts**: Fixed non-existent `BaseConfig` interface reference.
- **mcp_client_manager.ts**: Added type guards for `config.transport` to safely access transport-specific properties.
- **mcp_schema_fetcher.ts**: Added type cast for `resource` to resolve `uriTemplate` property mismatch with MCP SDK.

Fixes #2